### PR TITLE
GP-37735: Add certain relationships to 'Cooperation' case summary view.

### DIFF
--- a/CRM/DdVenueManager/Form/VenueContactPersonRelationship.php
+++ b/CRM/DdVenueManager/Form/VenueContactPersonRelationship.php
@@ -1,0 +1,182 @@
+<?php
+
+use Civi\DdVenueManager\Utils\VenueContactPersonLogic;
+
+/**
+ * This form uses to extend core Relationship form.
+ * The main goal is to fill 'case_id' field at 'civicrm_relationship' table.
+ * Some methods are copied and overridden without any changes.
+ */
+class CRM_DdVenueManager_Form_VenueContactPersonRelationship extends CRM_Contact_Form_Relationship {
+
+  public function preProcess() {
+    // huck to fix errors when parent form call the methods:
+    // $this->get('contactId') and $this->get('id')
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Integer', $this);
+    $relationshipId = CRM_Utils_Request::retrieve('id', 'Integer', $this);
+    $this->set('contactId', $contactId);
+    $this->set('id', $relationshipId);
+
+    parent::preProcess();
+  }
+
+  public function postProcess() {
+    parent::postProcess();
+
+    $contactId = CRM_Utils_Request::retrieve('cid', 'Integer', $this);
+    $caseId = CRM_Utils_Request::retrieve('caseID', 'Integer', $this);
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext(CRM_Utils_System::url('civicrm/contact/view/case', 'reset=1&action=view&cid=' . $contactId . '&id=' . $caseId));
+  }
+
+  public function setDefaultValues() {
+    $defaults = parent::setDefaultValues();
+
+    if ($this->getAction() == CRM_Core_Action::ADD || $this->getAction() == CRM_Core_Action::UPDATE) {
+      $relationshipTypeIdElement = $this->getElement('relationship_type_id');
+      $venueContactPersonRelationshipTypeId = VenueContactPersonLogic::getVenueContactPersonRelationTypeId();
+      $ABValue = $venueContactPersonRelationshipTypeId . '_a_b';
+      $BAValue = $venueContactPersonRelationshipTypeId . '_b_a';
+
+      if (Civi\DdVenueManager\Utils\FormUtils::isSelectValueExist($relationshipTypeIdElement, $ABValue)) {
+        $defaults['relationship_type_id'] = $ABValue;
+      } elseif (Civi\DdVenueManager\Utils\FormUtils::isSelectValueExist($relationshipTypeIdElement, $BAValue)) {
+        $defaults['relationship_type_id'] = $BAValue;
+      }
+    }
+
+    if ($this->getAction() == CRM_Core_Action::UPDATE) {
+      $defaults['is_permission_a_b'] = $this->_values['is_permission_a_b'];
+      $defaults['is_permission_b_a'] = $this->_values['is_permission_b_a'];
+    }
+
+    return $defaults;
+  }
+
+  /**
+   * The method is copied to fill 'case_id' field at 'civicrm_relationship' table.
+   * Added couple line of code.
+   *
+   * The method is copied from parent
+   * This code is got from CiviCRM 5.51.3
+   * See: civicrm/CRM/Contact/Form/Relationship.php
+   *
+   * @param array $values
+   *
+   * @return array
+   */
+  private function preparePostProcessParameters($values) {
+    $params = $values;
+    list($relationshipTypeId, $a, $b) = explode('_', $params['relationship_type_id']);
+
+    $params['relationship_type_id'] = $relationshipTypeId;
+    $params['contact_id_' . $a] = $this->_contactId;
+
+    if (empty($this->_relationshipId)) {
+      $params['contact_id_' . $b] = explode(',', $params['related_contact_id']);
+    }
+    else {
+      $params['id'] = $this->_relationshipId;
+      $params['contact_id_' . $b] = $params['related_contact_id'];
+    }
+
+    // If this is a b_a relationship these form elements are flipped
+    $params['is_permission_a_b'] = CRM_Utils_Array::value("is_permission_{$a}_{$b}", $values, 0);
+    $params['is_permission_b_a'] = CRM_Utils_Array::value("is_permission_{$b}_{$a}", $values, 0);
+
+    // this code are added:
+    if ($this->getAction() == CRM_Core_Action::ADD) {
+      $caseId = CRM_Utils_Request::retrieve('caseID', 'Integer', $this);
+      if (!empty($caseId)) {
+        $params['case_id'] = $caseId;
+      }
+    }
+    // end of added code
+
+    return [$params, $a];
+  }
+
+  /**
+   * The method is copied from parent form without any changes.
+   * This code is got from CiviCRM 5.51.3
+   * See: civicrm/CRM/Contact/Form/Relationship.php
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  public function submit($params) {
+    switch ($this->getAction()) {
+      case CRM_Core_Action::DELETE:
+        $this->deleteAction($this->_relationshipId);
+        return [];
+
+      case CRM_Core_Action::UPDATE:
+        return $this->updateAction($params);
+
+      default:
+        return $this->createAction($params);
+    }
+  }
+
+  /**
+   * The method is copied from parent form without any changes.
+   * This code is got from CiviCRM 5.51.3
+   * See: civicrm/CRM/Contact/Form/Relationship.php
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  private function updateAction($params) {
+    list($params, $_) = $this->preparePostProcessParameters($params);
+
+    unset($params['contact_id_b']);// to prevent error api3
+
+    try {
+      civicrm_api3('relationship', 'create', $params);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      throw new CRM_Core_Exception('Relationship create error ' . $e->getMessage());
+    }
+
+    $this->setMessage(['saved' => TRUE]);
+    return [$params, [$this->_relationshipId]];
+  }
+
+  /**
+   * The method is copied from parent form without any changes.
+   * This code is got from CiviCRM 5.51.3
+   * See: civicrm/CRM/Contact/Form/Relationship.php
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  private function createAction($params) {
+    list($params, $primaryContactLetter) = $this->preparePostProcessParameters($params);
+
+    $outcome = CRM_Contact_BAO_Relationship::createMultiple($params, $primaryContactLetter);
+
+    $relationshipIds = $outcome['relationship_ids'];
+
+    $this->setMessage($outcome);
+
+    return [$params, $relationshipIds];
+  }
+
+  /**
+   * The method is copied from parent form without any changes.
+   * This code is got from CiviCRM 5.51.3
+   * See: civicrm/CRM/Contact/Form/Relationship.php
+   *
+   * @param $id
+   */
+  private function deleteAction($id) {
+    CRM_Contact_BAO_Relationship::del($id);
+
+    // reload all blocks to reflect this change on the user interface.
+    $this->ajaxResponse['reloadBlocks'] = ['#crm-contactinfo-content'];
+  }
+
+}

--- a/Civi/DdVenueManager/Utils/CaseUtils.php
+++ b/Civi/DdVenueManager/Utils/CaseUtils.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Civi\DdVenueManager\Utils;
+
+use Civi\API\Exception\UnauthorizedException;
+use CRM_Case_BAO_Case;
+
+class CaseUtils {
+
+  /**
+   * @param $caseId
+   * @return string|null
+   * @throws \API_Exception
+   * @throws UnauthorizedException
+   */
+  public static function getCaseTypeNameById($caseId) {
+    if (empty($caseId)) {
+      return NULL;
+    }
+
+    $case = \Civi\Api4\CiviCase::get()
+      ->addSelect('case_type_id:name')
+      ->addWhere('id', '=', $caseId)
+      ->setLimit(1)
+      ->execute()
+      ->first();
+
+    return !empty($case['case_type_id:name']) ? $case['case_type_id:name'] : NULL;
+  }
+
+  /**
+   * @param $caseId
+   * @return int|null
+   */
+  public static function getCaseClientId($caseId) {
+    if (empty($caseId)) {
+      return NULL;
+    }
+
+    $clients = CRM_Case_BAO_Case::getCaseClients($caseId);
+    if (empty($clients[0])) {
+      return NULL;
+    }
+
+    return (int) $clients[0];
+  }
+
+}

--- a/Civi/DdVenueManager/Utils/Contact.php
+++ b/Civi/DdVenueManager/Utils/Contact.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Civi\DdVenueManager\Utils;
+
+
+use Civi\API\Exception\UnauthorizedException;
+
+class Contact {
+
+  /**
+   * @param $contactId
+   * @return string|null
+   * @throws \API_Exception
+   * @throws UnauthorizedException
+   */
+  public static function getSubType($contactId) {
+    if (empty($contactId)) {
+      return NULL;
+    }
+
+    $contact = \Civi\Api4\Contact::get()
+      ->addSelect('contact_sub_type:name')
+      ->addWhere('id', '=', $contactId)
+      ->execute()
+      ->first();
+
+    if (!empty($contact['contact_sub_type:name'])) {
+      return $contact['contact_sub_type:name'];
+    }
+
+    return NULL;
+  }
+
+}

--- a/Civi/DdVenueManager/Utils/FormUtils.php
+++ b/Civi/DdVenueManager/Utils/FormUtils.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Civi\DdVenueManager\Utils;
+
+class FormUtils {
+
+  /**
+   * @param $formElement
+   * @param $value
+   * @return bool
+   */
+  public static function isSelectValueExist($formElement, $value) {
+    if (empty($formElement->_options)) {
+      return false;
+    }
+
+    foreach ($formElement->_options as $option) {
+      if ($option['attr']['value'] === $value) {
+        return true;
+      }
+
+    }
+
+    return false;
+  }
+
+}

--- a/Civi/DdVenueManager/Utils/VenueContactPersonLogic.php
+++ b/Civi/DdVenueManager/Utils/VenueContactPersonLogic.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Civi\DdVenueManager\Utils;
+
+use Civi\API\Exception\UnauthorizedException;
+
+class VenueContactPersonLogic {
+
+  /**
+   * @param $caseId
+   * @return array|null
+   * @throws \API_Exception
+   * @throws UnauthorizedException
+   */
+  public static function getRelationsData($caseId) {
+    if (empty($caseId)) {
+      return NULL;
+    }
+
+    $preparedRelationships = [];
+
+    $relationships = \Civi\Api4\Relationship::get()
+      ->addSelect('id')
+      ->addSelect('phone.phone')
+      ->addSelect('email.email')
+      ->addSelect('contact.display_name')
+      ->addSelect('contact.id')
+      ->addSelect('Venue_Contact_Person_Details.Position')
+      ->addSelect('Venue_Contact_Person_Details.Primary')
+      ->addSelect('Venue_Contact_Person_Details.Decision_Maker')
+      ->addSelect('Venue_Contact_Person_Details.DDC_Disposition')
+      ->addSelect('Venue_Contact_Person_Details.DDC_Disposition:label')
+      ->addSelect('Venue_Contact_Person_Details.On_Site_Contact')
+      ->addWhere('relationship_type_id:name', '=', 'venue contact person')
+      ->addWhere('case_id', '=', $caseId)
+      ->addJoin('Contact AS contact', 'INNER', ['contact_id_b', '=', 'contact.id'])
+      ->addJoin('Email AS email', 'LEFT', ['contact_id_b', '=', 'email.contact_id'], ['email.is_primary', '=', 1])
+      ->addJoin('Phone AS phone', 'LEFT', ['contact_id_b', '=', 'phone.contact_id'], ['phone.is_primary', '=', 1])
+      ->execute();
+
+    foreach ($relationships as $relationship) {
+      $preparedRelationships[] = [
+        'relationship_id' => $relationship['id'],
+        'contact_display_name' => $relationship['contact.display_name'],
+        'contact_id' => $relationship['contact.id'],
+        'contact_primary_phone' => $relationship['phone.phone'],
+        'contact_primary_email' => $relationship['email.email'],
+        'venue_contact_position' => $relationship['Venue_Contact_Person_Details.Position'],
+        'venue_contact_primary' => $relationship['Venue_Contact_Person_Details.Primary'],
+        'venue_contact_ddc_disposition' => $relationship['Venue_Contact_Person_Details.DDC_Disposition'],
+        'venue_contact_on_site_contact' => $relationship['Venue_Contact_Person_Details.On_Site_Contact'],
+        'venue_contact_decision_maker' => $relationship['Venue_Contact_Person_Details.Decision_Maker'],
+        'venue_contact_decision_maker_label' => self::makeBooleanLabel($relationship['Venue_Contact_Person_Details.Decision_Maker']),
+        'venue_contact_on_site_contact_label' => self::makeBooleanLabel($relationship['Venue_Contact_Person_Details.On_Site_Contact']),
+        'venue_contact_primary_label' => self::makeBooleanLabel($relationship['Venue_Contact_Person_Details.Primary']),
+        'venue_contact_ddc_disposition_label' => $relationship['Venue_Contact_Person_Details.DDC_Disposition:label'],
+      ];
+    }
+
+    return $preparedRelationships;
+  }
+
+  /**
+   * @param $value
+   * @return mixed|string
+   */
+  public static function makeBooleanLabel($value) {
+    if ($value === null) {
+      return 'Not set';
+    }
+
+    if ($value === true) {
+      return 'Yes';
+    }
+
+    if ($value === false) {
+      return 'No';
+    }
+
+    return $value;
+  }
+
+  /**
+   * @param $relationTypeName
+   * @return string|null
+   * @throws UnauthorizedException
+   * @throws \API_Exception
+   */
+  public static function getRelationTypeIdByName($relationTypeName) {
+    if (empty($relationTypeName)) {
+      return NULL;
+    }
+
+    $relationshipType = \Civi\Api4\RelationshipType::get()
+      ->addSelect('id')
+      ->addWhere('name_a_b', '=', $relationTypeName)
+      ->execute()
+      ->first();
+
+    return !empty($relationshipType['id']) ? $relationshipType['id'] : null;
+  }
+
+  /**
+   * @return string|null
+   * @throws UnauthorizedException
+   * @throws \API_Exception
+   */
+  public static function getVenueContactPersonRelationTypeId() {
+    return VenueContactPersonLogic::getRelationTypeIdByName('venue contact person');
+  }
+
+}

--- a/Civi/DdVenueManager/Utils/VenueContactPersonLogic.php
+++ b/Civi/DdVenueManager/Utils/VenueContactPersonLogic.php
@@ -30,12 +30,12 @@ class VenueContactPersonLogic {
       ->addSelect('Venue_Contact_Person_Details.Decision_Maker')
       ->addSelect('Venue_Contact_Person_Details.DDC_Disposition')
       ->addSelect('Venue_Contact_Person_Details.DDC_Disposition:label')
-      ->addSelect('Venue_Contact_Person_Details.On_Site_Contact')
+      ->addSelect('Venue_Contact_Person_Details.On_Site_Contact:label')
       ->addWhere('relationship_type_id:name', '=', 'venue contact person')
       ->addWhere('case_id', '=', $caseId)
-      ->addJoin('Contact AS contact', 'INNER', ['contact_id_b', '=', 'contact.id'])
-      ->addJoin('Email AS email', 'LEFT', ['contact_id_b', '=', 'email.contact_id'], ['email.is_primary', '=', 1])
-      ->addJoin('Phone AS phone', 'LEFT', ['contact_id_b', '=', 'phone.contact_id'], ['phone.is_primary', '=', 1])
+      ->addJoin('Contact AS contact', 'INNER', ['contact_id_a', '=', 'contact.id'])
+      ->addJoin('Email AS email', 'LEFT', ['contact_id_a', '=', 'email.contact_id'], ['email.is_primary', '=', 1])
+      ->addJoin('Phone AS phone', 'LEFT', ['contact_id_a', '=', 'phone.contact_id'], ['phone.is_primary', '=', 1])
       ->execute();
 
     foreach ($relationships as $relationship) {
@@ -48,10 +48,9 @@ class VenueContactPersonLogic {
         'venue_contact_position' => $relationship['Venue_Contact_Person_Details.Position'],
         'venue_contact_primary' => $relationship['Venue_Contact_Person_Details.Primary'],
         'venue_contact_ddc_disposition' => $relationship['Venue_Contact_Person_Details.DDC_Disposition'],
-        'venue_contact_on_site_contact' => $relationship['Venue_Contact_Person_Details.On_Site_Contact'],
         'venue_contact_decision_maker' => $relationship['Venue_Contact_Person_Details.Decision_Maker'],
         'venue_contact_decision_maker_label' => self::makeBooleanLabel($relationship['Venue_Contact_Person_Details.Decision_Maker']),
-        'venue_contact_on_site_contact_label' => self::makeBooleanLabel($relationship['Venue_Contact_Person_Details.On_Site_Contact']),
+        'venue_contact_on_site_contact_label' => $relationship['Venue_Contact_Person_Details.On_Site_Contact:label'],
         'venue_contact_primary_label' => self::makeBooleanLabel($relationship['Venue_Contact_Person_Details.Primary']),
         'venue_contact_ddc_disposition_label' => $relationship['Venue_Contact_Person_Details.DDC_Disposition:label'],
       ];

--- a/dd_venue_manager.php
+++ b/dd_venue_manager.php
@@ -2,6 +2,8 @@
 
 require_once 'dd_venue_manager.civix.php';
 // phpcs:disable
+use Civi\DdVenueManager\Utils\CaseUtils;
+use Civi\DdVenueManager\Utils\VenueContactPersonLogic;
 use CRM_DdVenueManager_ExtensionUtil as E;
 // phpcs:enable
 
@@ -36,4 +38,58 @@ function dd_venue_manager_civicrm_links($operation, $objectName, $objectId, &$li
       'title' => 'Create Documents (CiviOffice)',
     ];
   }
+}
+// --- Functions below this ship commented out. Uncomment as required. ---
+
+/**
+ * Implements hook_civicrm_preProcess().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
+ */
+//function dd_venue_manager_civicrm_preProcess($formName, &$form): void {
+//
+//}
+
+/**
+ * Implements hook_civicrm_navigationMenu().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
+ */
+//function dd_venue_manager_civicrm_navigationMenu(&$menu): void {
+//  _dd_venue_manager_civix_insert_navigation_menu($menu, 'Mailings', [
+//    'label' => E::ts('New subliminal message'),
+//    'name' => 'mailing_subliminal_message',
+//    'url' => 'civicrm/mailing/subliminal',
+//    'permission' => 'access CiviMail',
+//    'operator' => 'OR',
+//    'separator' => 0,
+//  ]);
+//  _dd_venue_manager_civix_navigationMenu($menu);
+//}
+
+function dd_venue_manager_civicrm_caseSummary($caseID) {
+  $caseTypeName = CaseUtils::getCaseTypeNameById($caseID);
+  if ($caseTypeName !== 'Cooperation') {
+    return [];
+  }
+
+  $caseClientId = CaseUtils::getCaseClientId($caseID);
+  if (empty($caseClientId)) {
+    return [];
+  }
+
+  $contactSubType = Civi\DdVenueManager\Utils\Contact::getSubType($caseClientId);
+  if (in_array($contactSubType, ['Venue_Contact_Person', 'Venue'])) {
+    return [];
+  }
+
+  return [
+    'relationships' => [
+      'value' => (CRM_Core_Smarty::singleton())->fetchWith('CRM/DdVenueManager/Chunk/CaseSummaryVenueContactPersonRelationship.tpl', [
+        'relations' => VenueContactPersonLogic::getRelationsData($caseID),
+        'caseId' => $caseID,
+        'caseClientId' => $caseClientId,
+      ]),
+    ],
+  ];
 }

--- a/templates/CRM/DdVenueManager/Chunk/CaseSummaryVenueContactPersonRelationship.tpl
+++ b/templates/CRM/DdVenueManager/Chunk/CaseSummaryVenueContactPersonRelationship.tpl
@@ -1,6 +1,6 @@
 <div class="dd-venue-manager__venue-relations">
   <div class="crm-accordion-wrapper">
-    <div class="crm-accordion-header">Venue relations contact persons [{$relations|@count}]</div>
+    <div class="crm-accordion-header">Contact Persons [{$relations|@count}]</div>
     <div class="crm-accordion-body">
 
       <div class="crm-submit-buttons dd-venue-manager__venue-relations-add-new">
@@ -8,7 +8,7 @@
            href="{crmURL p='civicrm/dd-venue-manager/venue-contact-person-relationship' q="reset=1&id=`$relation.relationship_id`&cid=`$caseClientId`&caseID=`$caseId`&action=add"}"
         >
           <span class="crm-i fa-pencil"></span>
-          <span>Add new Relations</span>
+          <span>Add Contact Person</span>
         </a>
       </div>
 
@@ -23,7 +23,7 @@
               <th>Position</th>
               <th>Decision Maker?</th>
               <th>DDC Disposition</th>
-              <th>On-Site Contact Person?</th>
+              <th>On-Site Contact</th>
               <th>Actions</th>
             </tr>
               {foreach from=$relations item=relation}

--- a/templates/CRM/DdVenueManager/Chunk/CaseSummaryVenueContactPersonRelationship.tpl
+++ b/templates/CRM/DdVenueManager/Chunk/CaseSummaryVenueContactPersonRelationship.tpl
@@ -1,0 +1,79 @@
+<div class="dd-venue-manager__venue-relations">
+  <div class="crm-accordion-wrapper">
+    <div class="crm-accordion-header">Venue relations contact persons [{$relations|@count}]</div>
+    <div class="crm-accordion-body">
+
+      <div class="crm-submit-buttons dd-venue-manager__venue-relations-add-new">
+        <a class="button crm-hover-button crm-popup"
+           href="{crmURL p='civicrm/dd-venue-manager/venue-contact-person-relationship' q="reset=1&id=`$relation.relationship_id`&cid=`$caseClientId`&caseID=`$caseId`&action=add"}"
+        >
+          <span class="crm-i fa-pencil"></span>
+          <span>Add new Relations</span>
+        </a>
+      </div>
+
+      {if $relations}
+        <div class="dd-venue-manager__venue-relations-table">
+          <table class="dataTable">
+            <tr>
+              <th>Name</th>
+              <th>Phone</th>
+              <th>Email</th>
+              <th>Primary?</th>
+              <th>Position</th>
+              <th>Decision Maker?</th>
+              <th>DDC Disposition</th>
+              <th>On-Site Contact Person?</th>
+              <th>Actions</th>
+            </tr>
+              {foreach from=$relations item=relation}
+                <tr>
+                  <td>
+                    <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$relation.contact_id`"}"  target="_blank">{$relation.contact_display_name}</a>
+                  </td>
+                  <td>{$relation.contact_primary_phone}</td>
+                  <td>{$relation.contact_primary_email}</td>
+                  <td>{$relation.venue_contact_primary_label}</td>
+                  <td>{$relation.venue_contact_position}</td>
+                  <td>{$relation.venue_contact_decision_maker_label}</td>
+                  <td>{$relation.venue_contact_ddc_disposition_label}</td>
+                  <td>{$relation.venue_contact_on_site_contact_label}</td>
+                  <td>
+                    <a class="crm-hover-button crm-popup"
+                       href="{crmURL p='civicrm/dd-venue-manager/venue-contact-person-relationship' q="reset=1&id=`$relation.relationship_id`&cid=`$caseClientId`&caseID=`$caseId`&action=update"}"
+                    >
+                      <span class="crm-i fa-pencil"></span>
+                      <span>Edit</span>
+                    </a>
+
+                    <a class="crm-hover-button crm-popup"
+                       href="{crmURL p='civicrm/dd-venue-manager/venue-contact-person-relationship' q="reset=1&id=`$relation.relationship_id`&cid=`$caseClientId`&caseID=`$caseId`&action=delete"}"
+                    >
+                      <span class="crm-i fa-trash"></span>
+                      <span>Delete</span>
+                    </a>
+                  </td>
+                </tr>
+              {/foreach}
+          </table>
+        </div>
+      {else}
+        <div>This case has no venue relations.</div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+{literal}
+<style>
+
+.dd-venue-manager__venue-relations-table {
+  padding: 5px 0 20px 0;
+}
+
+.dd-venue-manager__venue-relations-add-new {
+  padding: 0 0 5px 0 !important;
+}
+
+</style>
+{/literal}

--- a/templates/CRM/DdVenueManager/Form/VenueContactPersonRelationship.tpl
+++ b/templates/CRM/DdVenueManager/Form/VenueContactPersonRelationship.tpl
@@ -1,0 +1,1 @@
+{include file="CRM/Contact/Form/Relationship.tpl"}

--- a/xml/Menu/dd_venue_manager.xml
+++ b/xml/Menu/dd_venue_manager.xml
@@ -6,4 +6,10 @@
     <title>CreateCaseActivityCiviOfficeDocument</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/dd-venue-manager/venue-contact-person-relationship</path>
+    <page_callback>CRM_DdVenueManager_Form_VenueContactPersonRelationship</page_callback>
+    <title>Venue person relation</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
-  Add to case Summary tables where you can `add/delete/create` relations.
- - It shows only when case client is has one of sub types: `Venue_Contact_Person`, `Venue` 
- - It shows only when case has type `Cooperation`
- - Contact A  in relations gets from case client.
- Create `VenueContactPersonRelationship` to override civi core page. See: civicrm/CRM/Contact/Form/Relationship.php. The main goal is to fill `case_id` field at `civicrm_relationship` table. Some methods are copied and overridden without any changes.